### PR TITLE
fix response

### DIFF
--- a/task-server.yaml
+++ b/task-server.yaml
@@ -297,15 +297,6 @@ paths:
                 code: 401
                 message: 'Unauthorized'
                 details: 'User ID not found in token'
-        '404':
-          description: Task not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-              example:
-                code: 404
-                message: 'Task not found'
         '500':
           description: Internal server error
           content:


### PR DESCRIPTION
削除時の冪等性を確保するため、タスクが存在しない場合も成功とみなす
タスクが存在しない場合404エラーを返すexampleを削除